### PR TITLE
最近の Java SE Document への対応

### DIFF
--- a/autoload/ref/javadoc.vim
+++ b/autoload/ref/javadoc.vim
@@ -102,6 +102,7 @@ function! s:get_root_directories() "{{{2
   let files = s:get_index_files([
         \ g:ref_javadoc_path . '/api/',
         \ g:ref_javadoc_path . '/jre/api/*/*/',
+        \ g:ref_javadoc_path . '/jre/api/*/*/*/',
         \ g:ref_javadoc_path . '/jdk/api/*/*/',
         \ ])
   return map(files,
@@ -187,10 +188,11 @@ endfunction
 
 function! s:gather_func(name)  "{{{2
   for fname in ['allclasses-noframe.html', 'allclasses-frame.html']
-  if filereadable(g:ref_javadoc_path.'/'.a:name.'/'.fname)
-    let list = readfile(g:ref_javadoc_path.'/'.a:name.'/'.fname)
-    call map(filter(list, 'v:val =~# "<A HREF="'), 'substitute(v:val, ".*A HREF=\"\\(.*\\)\\.html\".*", "\\1", "")')
-    return map(list, 'substitute(v:val, "/", ".", "g")')
+    if filereadable(g:ref_javadoc_path.'/'.a:name.'/'.fname)
+      let list = readfile(g:ref_javadoc_path.'/'.a:name.'/'.fname)
+      call map(filter(list, 'v:val =~? "<A HREF="'), 'substitute(v:val, ".*A HREF=\"\\(.*\\)\\.html\".*", "\\1", "")')
+      return map(list, 'substitute(v:val, "/", ".", "g")')
+    endif
   endfor
 endfunction
 


### PR DESCRIPTION
初めまして、http://www.oracle.com/technetwork/java/javase/downloads/index.html#docs からダウンロードできる Java SE 8 Document では動作しないようなので修正してみました。よろしければ取り込んでいただけますか。

修正点は以下の3点です、
* タグが小文字になっているようなので filter の適用条件を case insensitive に変更
* endif が欠落していたのを修正
* jre の検索対象のディレクトリーの深さを修正