### PR TITLE
Windows への対応

### DIFF
--- a/autoload/ref/javadoc.vim
+++ b/autoload/ref/javadoc.vim
@@ -10,6 +10,8 @@ set cpo&vim
 " config. {{{1
 if !exists('g:ref_javadoc_path')  " {{{2
   let g:ref_javadoc_path = ''
+else
+  let g:ref_javadoc_path = substitute(g:ref_javadoc_path, '\\', '/', 'g')
 endif
 
 if !exists('g:ref_javadoc_cmd')  " {{{2
@@ -111,7 +113,7 @@ endfunction
 function! s:get_index_files(re_paths) " {{{2
   let files = []
   for re_path in a:re_paths
-    let files += split(glob(re_path . '/allclasses-noframe.html'), "\n")
+    let files += map(split(glob(re_path . '/allclasses-noframe.html'), "\n"), 'substitute(v:val, "\\\\", "/", "g")')
   endfor
   return files
 endfunction


### PR DESCRIPTION
Windows では動作しないようなので、対応してみました。こちらも、よろしければ取り込んで頂けますか。

修正点以下の2点です。
- g:ref_javadoc_path にバックスラッシュを含む場合はスラッシュに置換
- s:get_index_files 中の glob が返すパスがバックスラッシュを含むためスラッシュに置換
